### PR TITLE
Add basic support for foreign key

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 
     <groupId>org.isaacmcfadyen</groupId>
     <artifactId>d1-jdbc-driver</artifactId>
-    <version>1.1</version>
+    <version>1.1.1</version>
     <packaging>jar</packaging>
 
     <properties>


### PR DESCRIPTION
# Detail

Add basic support for foreign key.

This will allow foreign keys to be displayed in DataGrip.

# Limitation

In SQLite, you can name foreign key constraints when you `CREATE TABLE` . 

However, the foreign key constraint names themselves are not stored anywhere as table columns. System tables have SQL but are hard to reference.  
[How to get the names of foreign key constraints in SQLite? - Stack Overflow](https://stackoverflow.com/questions/41595152/how-to-get-the-names-of-foreign-key-constraints-in-sqlite)

Therefore, the foreign key constraint name is currently fixed to  `<table_name>_<id>_<seq>`. 

For more information, please see the screenshots.

# Screenshot


![スクリーンショット 2024-05-06 193256_fixed](https://github.com/isaac-mcfadyen/d1-jdbc-driver/assets/1299734/326e0c6b-8d75-4840-b48a-6765936b18d7)


# Test

I have confirmed that it works by following these steps.

1. Create a new database in Cloudflare D1.  (like name: `d1-driver-test`)
2. Save the following SQL to a file.

```sql
CREATE TABLE `shops` (
  `id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
  `name` text
);

CREATE TABLE `staffs` (
  `id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
  `name` text
);

CREATE TABLE `products` (
  `id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
  `name` text
);

CREATE TABLE `orders` (
  `id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
  `name` text,
  `product_id` integer,
  `shop_id` integer,
  `staff_id` integer,
  FOREIGN KEY (`product_id`) REFERENCES `products`(`id`) ON UPDATE cascade ON DELETE set null,
  FOREIGN KEY (`shop_id`) REFERENCES `shops`(`id`) ON UPDATE set default ON DELETE restrict,	
  CONSTRAINT `fk__staff_who_ordered` FOREIGN KEY (`staff_id`) REFERENCES `staffs`(`id`) ON UPDATE no action ON DELETE no action
);
```

3. Execute SQL in Wrangler.

```
npx wrangler d1 execute d1-driver-test --remote --file=./d1.sql
```

4. The result looks like the screenshot.

